### PR TITLE
Fix package imports, add missing CancelSession.

### DIFF
--- a/cat_handler.go
+++ b/cat_handler.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/zhulik/margelet"
+	"gopkg.in/telegram-bot-api.v2"
 )
 
 type CatHandler struct {

--- a/config_session_handler.go
+++ b/config_session_handler.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"errors"
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+
 	"github.com/zhulik/margelet"
+	"gopkg.in/telegram-bot-api.v2"
 )
 
 type ConfigSessionHandler struct {
@@ -53,4 +54,7 @@ func (session ConfigSessionHandler) reply(bot margelet.MargeletAPI, message tgbo
 	msg.ChatID = message.Chat.ID
 	msg.ReplyToMessageID = message.MessageID
 	bot.Send(msg)
+}
+
+func (session ConfigSessionHandler) CancelSession(bot margelet.MargeletAPI, message tgbotapi.Message, responses []tgbotapi.Message) {
 }

--- a/utils.go
+++ b/utils.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"errors"
-	"github.com/go-telegram-bot-api/telegram-bot-api"
-	"github.com/zhulik/margelet"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/zhulik/margelet"
+	"gopkg.in/telegram-bot-api.v2"
 )
 
 const (


### PR DESCRIPTION
This example bot no longer built as the imports changed for tgbotapi. Additionally, it was missing a CancelSession method. 

This PR resolves both of these issues. 
